### PR TITLE
Update compatibility w new Samtools 1.x release and add MapComp iterative script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@
 00_archive/*
 02_data/00_archive/*
 bwa.*
+02_data/num_markers_assigned.txt
+03_mapped/paired_anon_names.txt
+03_mapped/pairings_out.txt
+
 
 # un-ignore
 !/02_data/genome/tutorial_genome.fasta

--- a/01_scripts/01_bwa_align_reads.sh
+++ b/01_scripts/01_bwa_align_reads.sh
@@ -36,7 +36,7 @@ samtools view -Sb -F 4 ${INPUT_FASTA}.sam > ${INPUT_FASTA}.mapped_only.bam 2> /d
 
 # Sort reads
 echo "  Sorting bam file..."
-samtools sort ${INPUT_FASTA}.mapped_only.bam ${INPUT_FASTA}.sorted 2> /dev/null
+samtools sort ${INPUT_FASTA}.mapped_only.bam -o ${INPUT_FASTA}.sorted.bam 2> /dev/null
 
 # clean temporary files
 rm ${INPUT_FASTA}.mapped_only.bam

--- a/01_scripts/utility_scripts/fasta_remove.py
+++ b/01_scripts/utility_scripts/fasta_remove.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Extract sequences from a fasta file if their name is not in a 'remove' file.
+
+Remove file contains one sequence name per line.
+
+Usage:
+    %program <input_file> <remove_file> <output_file>"""
+
+import sys
+import re
+
+try:
+    from Bio import SeqIO
+except:
+    print "This program requires the Biopython library"
+    sys.exit(0)
+
+try:
+    fasta_file = sys.argv[1]  # Input fasta file
+    remove_file = sys.argv[2] # Input remove file, one gene name per line
+    result_file = sys.argv[3] # Output fasta file
+except:
+    print __doc__
+    sys.exit(0)
+
+remove = set()
+with open(remove_file) as f:
+    for line in f:
+        line = line.strip()
+        if line != "":
+            remove.add(line)
+
+fasta_sequences = SeqIO.parse(open(fasta_file),'fasta')
+
+with open(result_file, "w") as f:
+    for seq in fasta_sequences:
+        name = seq.name
+        if name not in remove and len(seq.seq.tostring()) > 0:
+            SeqIO.write([seq], f, "fasta")
+

--- a/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
+++ b/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
@@ -1,0 +1,55 @@
+# Pair using MapComp, then remove the anonymous paired markers from the input fasta file and redo the pairings again
+
+#Note: requires 01_scripts/fasta_remove.py
+#Note: requires biopython
+
+# Set the species name of the anon markers
+ANON="Salp.anon"
+
+# Standard files
+WANTED_LOCI="03_mapped/wanted_loci.info"
+PAIRINGS_OUT="03_mapped/pairings_out.txt"
+PAIRINGS_NAMES="03_mapped/paired_anon_names.txt"
+
+# Prevent carry-over from previous rounds
+rm 02_data/num_markers_assigned.txt 2>/dev/null
+rm $PAIRINGS_OUT 2>/dev/null
+
+# Backup the markers file as it will be affected during the run
+cp 02_data/markers.fasta 02_data/markers.fasta.pre
+
+for i in $(seq 1 10 )
+do
+    echo "## MapComp to assign position to $ANON markers"
+    ./mapcomp
+    
+    # Retain paired output
+    echo "## Number of paired $ANON markers identified this round = "
+    grep -E "^$ANON" 03_mapped/wanted_loci.info | wc -l
+    grep -E "^$ANON" 03_mapped/wanted_loci.info >> 03_mapped/pairings_out.txt 
+    echo "## Number of paired $ANON markers identified in total = "
+    wc -l $PAIRINGS_OUT
+
+    # Obtain names of anonymous markers that were paired this round
+    awk -v var=$ANON '{ print var "_1_0_0_" $5 }' $PAIRINGS_OUT > $PAIRINGS_NAMES
+    PAIRINGS_NUM=`wc -l $PAIRINGS_NAMES`
+    echo $PAIRINGS_NUM >> 02_data/num_markers_assigned.txt
+    echo "## Number of $ANON markers assigned positions this round"
+    echo $PAIRINGS_NUM
+    
+    # Remove paired markers from fasta
+    ./01_scripts/fasta_remove.py ./02_data/markers.fasta $PAIRINGS_NAMES 02_data/markers_remaining.fasta
+     
+    # Replace original markers file with the removed markers file
+    mv 02_data/markers_remaining.fasta 02_data/markers.fasta
+    
+    echo "## Number of $ANON markers remaining = "
+    grep -c ">$ANON" 02_data/markers.fasta 
+done
+
+# Replace the marker removed markers.fasta with the original one saved at the start 
+echo "## Replacing the reduced fasta file with the original fasta file"
+mv 02_data/markers.fasta.pre 02_data/markers.fasta
+wc -l 02_data/markers.fasta
+
+# TODO Fix using the .pre to replace fasta at the end as this can result in problems if one stops the process mid-process

--- a/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
+++ b/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
@@ -1,16 +1,23 @@
 # Pair using MapComp, then remove the anonymous paired markers from the input fasta file and redo the pairings again
+# NOTE: this is currently destructive to the markers.fasta file in 02_data/ so always have a second version saved elsewere that can be easily re-copied back into this repo. 
 
-#Note: requires biopython
-#Note: requires 01_scripts/utility_scripts/fasta_remove.py
-# This script was developed by Eric Normandeau
-# https://github.com/enormandeau/Scripts
+# Dependencies:
+# Requires biopython
+# Requires 01_scripts/utility_scripts/fasta_remove.py
+#   The fasta_remove.py script was developed by Eric Normandeau
+#   https://github.com/enormandeau/Scripts
 
-# Known issues:
-# TODO Fix using the .pre to replace fasta at the end as this can result in problems if one stops the process mid-process
-# For now, just don't keep the only copy of the markers file in this repo.
-
+# Setup:
 # Set the species name of the anon markers
 ANON="Salp.anon"
+# this will correspond to the first field in the fasta accession name (e.g. >Salp.anon_1_0_0_29)
+
+# Run all from the main directory:
+# ./01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
+
+# TODO Fix using the .pre to replace fasta at the end as this can result in problems if one stops the process mid-process
+
+
 
 # Standard files
 WANTED_LOCI="03_mapped/wanted_loci.info"

--- a/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
+++ b/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
@@ -1,7 +1,13 @@
 # Pair using MapComp, then remove the anonymous paired markers from the input fasta file and redo the pairings again
 
-#Note: requires 01_scripts/fasta_remove.py
 #Note: requires biopython
+#Note: requires 01_scripts/fasta_remove.py
+# This script was developed by Eric Normandeau
+# https://github.com/enormandeau/Scripts
+
+# Known issues:
+# TODO Fix using the .pre to replace fasta at the end as this can result in problems if one stops the process mid-process
+# For now, just don't keep the only copy of the markers file in this repo.
 
 # Set the species name of the anon markers
 ANON="Salp.anon"
@@ -52,4 +58,3 @@ echo "## Replacing the reduced fasta file with the original fasta file"
 mv 02_data/markers.fasta.pre 02_data/markers.fasta
 wc -l 02_data/markers.fasta
 
-# TODO Fix using the .pre to replace fasta at the end as this can result in problems if one stops the process mid-process

--- a/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
+++ b/01_scripts/utility_scripts/remove_paired_anon_and_pair_again.sh
@@ -1,7 +1,7 @@
 # Pair using MapComp, then remove the anonymous paired markers from the input fasta file and redo the pairings again
 
 #Note: requires biopython
-#Note: requires 01_scripts/fasta_remove.py
+#Note: requires 01_scripts/utility_scripts/fasta_remove.py
 # This script was developed by Eric Normandeau
 # https://github.com/enormandeau/Scripts
 
@@ -44,7 +44,7 @@ do
     echo $PAIRINGS_NUM
     
     # Remove paired markers from fasta
-    ./01_scripts/fasta_remove.py ./02_data/markers.fasta $PAIRINGS_NAMES 02_data/markers_remaining.fasta
+    ./01_scripts/utility_scripts/fasta_remove.py ./02_data/markers.fasta $PAIRINGS_NAMES 02_data/markers_remaining.fasta
      
     # Replace original markers file with the removed markers file
     mv 02_data/markers_remaining.fasta 02_data/markers.fasta

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In order to use MapComp, you will need the following:
 - Python 2.7
 - numpy (Python library)
 - bwa
-- samtools
+- samtools (1.x release) 
 - The R statistical language
 
 If you are using a Debian derived Linux distribution, for example Ubuntu or


### PR DESCRIPTION
The new Samtools releases require:
1) -o to designate output filename in samtools sort command
2) that the .bam extension is manually added to the output from samtools sort (no longer automatic)

The README.md has been updated to note requirements for samtools 1.x, a major version update (see http://samtools.sourceforge.net and htslib.org for newest version).